### PR TITLE
chore: stops buffering beyond the limit if the action is to reject.

### DIFF
--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -1,0 +1,15 @@
+# Rationale
+
+This document contains some rationale around certain decisions or explain potential failure modes in Coraza.
+
+## Why limits should be chosen very carefuly
+
+The only way Coraza can inspect a request body and resolve its legitimity before it reaches upstream is by buffer the body payload, analyse it and then send it to upstream if no threads detected. The main issue with buffering is that if not handled correctly it can become a potential attack door by itself. The buffering process occurs as follows:
+
+1. First, Coraza attempts to buffer the body in memory up to a limit defined by the directive `SecRequestBodyMemoryLimit`, by default Coraza sets `131072`.
+2. If the body payload is bigger than the memory limit, Coraza moves off the memory buffering and buffers the body in disk.
+
+Both actions represent a risk when the configuration isn't defensive enough:
+
+1. Buffering in memory, when the limit is high can cause OOM in the system as there is no soft or hard limit on how much memory can be spent on buffering, the OOM will not only affect the attack request but the entire process. It is recommended to keep the default value or lower.
+2. Buffering in disk, when not setting the right action can become problematic: an attacker could send huge payloads which will be stored in disk and without proper mitigation (e.g. hard limit on request size or rate limiting) it could fill up the disk, causing degraded functioning in the host. One way to prevent this is to use `SecRequestBodyLimitAction reject` setting, meaning that beyond the request body limit, the request is rejected and no more bytes are writen to disk. Once the request is finished, the buffering file is deleted.

--- a/RATIONALE.md
+++ b/RATIONALE.md
@@ -4,7 +4,7 @@ This document contains some rationale around certain decisions or explain potent
 
 ## Why limits should be chosen very carefuly
 
-The only way Coraza can inspect a request body and resolve its legitimity before it reaches upstream is by buffer the body payload, analyse it and then send it to upstream if no threads detected. The main issue with buffering is that if not handled correctly it can become a potential attack door by itself. The buffering process occurs as follows:
+Coraza can inspect a request body and resolve its legitimacy before it reaches upstream by buffering the body payload, analyzing it, and then sending it upstream if no threads are detected. The main issue with buffering is that it can become a potential attack door by itself if not handled correctly. The buffering process occurs as follows:
 
 1. First, Coraza attempts to buffer the body in memory up to a limit defined by the directive `SecRequestBodyMemoryLimit`, by default Coraza sets `131072`.
 2. If the body payload is bigger than the memory limit, Coraza moves off the memory buffering and buffers the body in disk.
@@ -12,4 +12,4 @@ The only way Coraza can inspect a request body and resolve its legitimity before
 Both actions represent a risk when the configuration isn't defensive enough:
 
 1. Buffering in memory, when the limit is high can cause OOM in the system as there is no soft or hard limit on how much memory can be spent on buffering, the OOM will not only affect the attack request but the entire process. It is recommended to keep the default value or lower.
-2. Buffering in disk, when not setting the right action can become problematic: an attacker could send huge payloads which will be stored in disk and without proper mitigation (e.g. hard limit on request size or rate limiting) it could fill up the disk, causing degraded functioning in the host. One way to prevent this is to use `SecRequestBodyLimitAction reject` setting, meaning that beyond the request body limit, the request is rejected and no more bytes are writen to disk. Once the request is finished, the buffering file is deleted.
+2. Buffering in the disk, when not setting the right action can become problematic: an attacker could send huge payloads which will be stored in the disk and without proper mitigation (e.g. hard limit on request size or rate limiting) it could fill up the disk, causing degraded functioning in the host. One way to prevent this is to use `SecRequestBodyLimitAction reject` setting, meaning that beyond the request body limit, the request is rejected and no more bytes are written to the disk. Once the request is finished, the buffered file is deleted.

--- a/actions/prepend.go
+++ b/actions/prepend.go
@@ -36,7 +36,6 @@ func (a *prependFn) Evaluate(r rules.RuleMetadata, txS rules.TransactionState) {
 	buf := corazawaf.NewBodyBuffer(types.BodyBufferOptions{
 		TmpPath:     tx.WAF.TmpDir,
 		MemoryLimit: tx.WAF.RequestBodyInMemoryLimit,
-		Limit:       tx.WAF.RequestBodyLimit,
 	})
 
 	_, err := buf.Write([]byte(data))

--- a/actions/prepend.go
+++ b/actions/prepend.go
@@ -36,6 +36,7 @@ func (a *prependFn) Evaluate(r rules.RuleMetadata, txS rules.TransactionState) {
 	buf := corazawaf.NewBodyBuffer(types.BodyBufferOptions{
 		TmpPath:     tx.WAF.TmpDir,
 		MemoryLimit: tx.WAF.RequestBodyInMemoryLimit,
+		Limit:       tx.WAF.RequestBodyLimit,
 	})
 
 	_, err := buf.Write([]byte(data))

--- a/config.go
+++ b/config.go
@@ -53,14 +53,11 @@ func NewWAFConfig() WAFConfig {
 
 // RequestBodyConfig controls access to the request body.
 type RequestBodyConfig interface {
-	// WithLimit sets the maximum number of bytes that can be read from the request body. Going beyond WithInMemoryLimit will
-	// result in buffering to disk.
-	// The settable upper limit for 32-bit machines is 2147483647 bytes (2GiB)
+	// WithLimit sets the maximum number of bytes that can be read from the request body.
+	// A request going beyond WithInMemoryLimit will result in buffering to disk.
 	WithLimit(limit int) RequestBodyConfig
 
 	// WithInMemoryLimit sets the maximum number of bytes that can be read from the request body and buffered in memory.
-	// Keep in mind your machine architecture and memory/swap limits while setting it.
-	// E.g. 32-bit machine tested limit: 1073741824 (1GiB)
 	WithInMemoryLimit(limit int) RequestBodyConfig
 }
 

--- a/config.go
+++ b/config.go
@@ -53,11 +53,14 @@ func NewWAFConfig() WAFConfig {
 
 // RequestBodyConfig controls access to the request body.
 type RequestBodyConfig interface {
-	// WithLimit sets the maximum number of bytes that can be read from the request body. Bytes beyond that set
-	// in WithInMemoryLimit will be buffered to disk.
+	// WithLimit sets the maximum number of bytes that can be read from the request body. Going beyond WithInMemoryLimit will
+	// result in buffering to disk.
+	// The settable upper limit for 32-bit machines is 2147483647 bytes (2GiB)
 	WithLimit(limit int) RequestBodyConfig
 
 	// WithInMemoryLimit sets the maximum number of bytes that can be read from the request body and buffered in memory.
+	// Keep in mind your machine architecture and memory/swap limits while setting it.
+	// E.g. 32-bit machine tested limit: 1073741824 (1GiB)
 	WithInMemoryLimit(limit int) RequestBodyConfig
 }
 
@@ -69,6 +72,8 @@ func NewRequestBodyConfig() RequestBodyConfig {
 // ResponseBodyConfig controls access to the response body.
 type ResponseBodyConfig interface {
 	// WithLimit sets the maximum number of bytes that can be read from the response body and buffered in memory.
+	// Keep in mind your machine architecture and memory/swap limits while setting it.
+	// E.g. 32-bit machine tested limit: 1073741824 (1GiB)
 	WithLimit(limit int) ResponseBodyConfig
 
 	// WithInMemoryLimit is not implemented for ResponseBody. The body will be just buffered in memory,

--- a/config.go
+++ b/config.go
@@ -71,6 +71,9 @@ type ResponseBodyConfig interface {
 	// WithLimit sets the maximum number of bytes that can be read from the response body and buffered in memory.
 	WithLimit(limit int) ResponseBodyConfig
 
+	// WithInMemoryLimit is not implemented for ResponseBody. The body will be just buffered in memory,
+	// therefore WithLimit already sets the in memory threshold
+
 	// WithMimeTypes sets the mime types of responses that will be processed.
 	WithMimeTypes(mimeTypes []string) ResponseBodyConfig
 }

--- a/internal/corazawaf/body_buffer.go
+++ b/internal/corazawaf/body_buffer.go
@@ -30,9 +30,13 @@ func (br *BodyBuffer) Write(data []byte) (n int, err error) {
 		return 0, nil
 	}
 
-	l := int64(len(data)) + br.length
-	if l > br.options.MemoryLimit {
+	l := br.length + int64(len(data))
+
+	// Check if memory limits are reached or if l is overflown
+	// TODO write about real limit even if programmatically the overflow is checked.
+	if l > br.options.MemoryLimit || l < 0 {
 		if environment.IsTinyGo {
+			// TinyGo: Bytes beyond MemoryLimit are not written
 			maxWritingDataLen := br.options.MemoryLimit - br.length
 			if maxWritingDataLen == 0 {
 				return 0, nil
@@ -40,19 +44,31 @@ func (br *BodyBuffer) Write(data []byte) (n int, err error) {
 			br.length = br.options.MemoryLimit
 			return br.buffer.Write(data[:maxWritingDataLen])
 		} else {
-			if br.writer == nil {
-				br.writer, err = os.CreateTemp(br.options.TmpPath, "body*")
-				if err != nil {
-					return 0, err
+			// Default: The total limit is checked
+			if l > br.options.Limit {
+				// If exceeded, bytes beyond Limit are not written
+				maxWritingDataLen := br.options.Limit - br.length
+				if maxWritingDataLen == 0 {
+					return 0, nil
 				}
-				// we dump the previous buffer
-				if _, err := br.writer.Write(br.buffer.Bytes()); err != nil {
-					return 0, err
+				br.length = br.options.Limit
+				return br.buffer.Write(data[:maxWritingDataLen])
+			} else {
+				// If not exceeded, bytes beyond MemoryLimit are buffered to disk
+				if br.writer == nil {
+					br.writer, err = os.CreateTemp(br.options.TmpPath, "body*")
+					if err != nil {
+						return 0, err
+					}
+					// we dump the previous buffer
+					if _, err := br.writer.Write(br.buffer.Bytes()); err != nil {
+						return 0, err
+					}
+					defer br.buffer.Reset()
 				}
-				br.buffer.Reset()
+				br.length = l
+				return br.writer.Write(data)
 			}
-			br.length = l
-			return br.writer.Write(data)
 		}
 	}
 

--- a/internal/corazawaf/body_buffer.go
+++ b/internal/corazawaf/body_buffer.go
@@ -42,8 +42,8 @@ func (br *BodyBuffer) Write(data []byte) (n int, err error) {
 	var l int64
 
 	// Overflow check
-	if br.length > (math.MaxInt64 - int64(len(data))) {
-		// Overflow, buffer length will always be at most MaxInt
+	if br.length >= (math.MaxInt64 - int64(len(data))) {
+		// Overflow, buffer length will always be at most MaxInt64
 		l = math.MaxInt64
 		maxWritingDataLenBeforeOverflow = math.MaxInt64 - br.length
 	} else {

--- a/internal/corazawaf/body_buffer.go
+++ b/internal/corazawaf/body_buffer.go
@@ -5,7 +5,6 @@ package corazawaf
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"math"
 	"os"
@@ -47,7 +46,6 @@ func (br *BodyBuffer) Write(data []byte) (n int, err error) {
 		// No Overflow
 		targetLen = br.length + int64(len(data))
 	}
-	fmt.Println(targetLen, br.options.MemoryLimit)
 
 	// Check if memory or disk limits are reached
 	// Even if Overflow is explicitly checked, MemoryLimit real limits are below maxInt and machine dependenent.
@@ -81,7 +79,6 @@ func (br *BodyBuffer) Write(data []byte) (n int, err error) {
 
 			// Total limit is checked
 			if targetLen >= br.options.Limit {
-				fmt.Println(targetLen, br.options.Limit)
 				br.lengthIsBeyondLimit = true
 				if br.options.DiscardOnBodyLimit {
 					return 0, nil
@@ -93,7 +90,6 @@ func (br *BodyBuffer) Write(data []byte) (n int, err error) {
 				br.length = targetLen
 				return br.writer.Write(data)
 			}
-			return br.writer.Write(data)
 		}
 	}
 

--- a/internal/corazawaf/body_buffer.go
+++ b/internal/corazawaf/body_buffer.go
@@ -79,33 +79,19 @@ func (br *BodyBuffer) Write(data []byte) (n int, err error) {
 				}
 				br.buffer.Reset()
 			}
-			// Total (disk) limit is checked
-			if l > br.options.Limit {
-				// Total limit exceeded, bytes beyond Limit are not buffered
-				maxWritingDataLen := br.options.Limit - br.length
-				if maxWritingDataLen == 0 {
-					return 0, nil
-				}
-				br.length = br.options.Limit
-				return br.writer.Write(data[:maxWritingDataLen])
-			} else {
-				// Total limit not exceeded, bytes are buffered to disk
-				br.length = l
-				if maxWritingDataLenBeforeOverflow == NotOverflow {
-					return br.writer.Write(data)
-				} else {
-					return br.writer.Write(data[:maxWritingDataLenBeforeOverflow])
-				}
+			// Bytes are buffered to disk
+			br.length = l
+			if maxWritingDataLenBeforeOverflow != NotOverflow {
+				return br.writer.Write(data[:maxWritingDataLenBeforeOverflow])
 			}
+			return br.writer.Write(data)
 		}
 	}
-
 	br.length = l
-	if maxWritingDataLenBeforeOverflow == NotOverflow {
-		return br.buffer.Write(data)
-	} else {
+	if maxWritingDataLenBeforeOverflow != NotOverflow {
 		return br.buffer.Write(data[:maxWritingDataLenBeforeOverflow])
 	}
+	return br.buffer.Write(data)
 }
 
 // Reader Returns a working reader for the body buffer in memory or file

--- a/internal/corazawaf/body_buffer_test.go
+++ b/internal/corazawaf/body_buffer_test.go
@@ -112,16 +112,16 @@ func TestWriteOverLimit(t *testing.T) {
 		t.Errorf("unexpected number of bytes in write, want: %d, have: %d", want, have)
 	}
 
-	buf := new(strings.Builder)
 	reader, err := br.Reader()
 	if err != nil {
-		t.Error(err)
+		t.Fatalf("unexpected error: %s", err.Error())
 	}
-	if _, err := io.Copy(buf, reader); err != nil {
-		t.Error(err)
+	buf, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err.Error())
 	}
-	if buf.String() != "ab" {
-		t.Error("Failed to get BodyReader from file")
+	if want, have := "ab", string(buf); want != have {
+		t.Errorf("unexpected body in file, want: %s, have: %s", want, have)
 	}
 	_ = br.Reset()
 }

--- a/internal/corazawaf/body_buffer_test.go
+++ b/internal/corazawaf/body_buffer_test.go
@@ -44,7 +44,6 @@ func TestBodyReaderFile(t *testing.T) {
 	br := NewBodyBuffer(types.BodyBufferOptions{
 		TmpPath:     t.TempDir(),
 		MemoryLimit: 1,
-		Limit:       50,
 	})
 	if _, err := br.Write([]byte("test")); err != nil {
 		t.Error(err)
@@ -90,38 +89,6 @@ func TestBodyReaderWriteFromReader(t *testing.T) {
 	}
 	if buf.String() != "test" {
 		t.Error("Failed to write bodyreader from io.Reader")
-	}
-	_ = br.Reset()
-}
-
-func TestWriteOverLimit(t *testing.T) {
-	if environment.IsTinyGo {
-		return // t.Skip doesn't work on TinyGo
-	}
-	br := NewBodyBuffer(types.BodyBufferOptions{
-		TmpPath:     t.TempDir(),
-		MemoryLimit: 0,
-		Limit:       2,
-	})
-	n, err := br.Write([]byte{'a', 'b', 'c', 'd', 'e'})
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err.Error())
-	}
-
-	if want, have := 2, n; want != have {
-		t.Errorf("unexpected number of bytes in write, want: %d, have: %d", want, have)
-	}
-
-	reader, err := br.Reader()
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err.Error())
-	}
-	buf, err := io.ReadAll(reader)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err.Error())
-	}
-	if want, have := "ab", string(buf); want != have {
-		t.Errorf("unexpected body in file, want: %s, have: %s", want, have)
 	}
 	_ = br.Reset()
 }

--- a/internal/corazawaf/body_buffer_tinygo_test.go
+++ b/internal/corazawaf/body_buffer_tinygo_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/corazawaf/coraza/v3/types"
 )
 
-func TestWriteOverLimit(t *testing.T) {
+func TestTinyGoWriteOverLimit(t *testing.T) {
 	br := NewBodyBuffer(types.BodyBufferOptions{
 		MemoryLimit: 2,
 	})

--- a/internal/corazawaf/transaction.go
+++ b/internal/corazawaf/transaction.go
@@ -778,7 +778,7 @@ func (tx *Transaction) ProcessRequestBody() (*types.Interruption, error) {
 		return nil, err
 	}
 
-	// Chunked requests will always be written to a temporary file
+	// Check if the RequestBodyLimit is reached
 	if tx.RequestBodyBuffer.Size() >= tx.RequestBodyLimit {
 		tx.variables.inboundErrorData.Set("1")
 		if tx.WAF.RequestBodyLimitAction == types.RequestBodyLimitActionReject {

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -216,7 +216,7 @@ func TestRequestBody(t *testing.T) {
 			} else {
 				val := tx.variables.argsPost.Get("some")
 				if len(val) != 1 || val[0] != "result" {
-					t.Error("Failed to set url encoded post data")
+					t.Errorf("Failed to set urlencoded POST data with arguments: \"%s\"", strings.Join(val, "\", \""))
 				}
 			}
 

--- a/internal/corazawaf/transaction_test.go
+++ b/internal/corazawaf/transaction_test.go
@@ -150,13 +150,13 @@ func TestRequestBody(t *testing.T) {
 		shouldInterrupt        bool
 	}{
 		{
-			name:                   "no memory buffer and limit not reach",
+			name:                   "no memory buffer and limit not reached",
 			requestBodyMemoryLimit: 0,
 			requestBodyLimit:       urlencodedBodyLen + 1,
 			requestBodyLimitAction: types.BodyLimitActionReject,
 		},
 		{
-			name:                   "memory buffer and limit not reach",
+			name:                   "memory buffer and limit not reached",
 			requestBodyMemoryLimit: urlencodedBodyLen / 2,
 			requestBodyLimit:       urlencodedBodyLen + 2,
 			requestBodyLimitAction: types.BodyLimitActionReject,

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -184,13 +184,11 @@ func (w *WAF) newTransactionWithID(id string) *Transaction {
 		tx.RequestBodyBuffer = NewBodyBuffer(types.BodyBufferOptions{
 			TmpPath:     w.TmpDir,
 			MemoryLimit: w.RequestBodyInMemoryLimit,
-			Limit:       tx.WAF.RequestBodyLimit,
 		})
 		tx.ResponseBodyBuffer = NewBodyBuffer(types.BodyBufferOptions{
 			TmpPath: w.TmpDir,
 			// the response body is just buffered in memory. Therefore, Limit and MemoryLimit are equal.
 			MemoryLimit: w.ResponseBodyLimit,
-			Limit:       w.ResponseBodyLimit,
 		})
 		tx.variables = *NewTransactionVariables()
 		tx.transformationCache = map[transformationKey]*transformationValue{}

--- a/internal/corazawaf/waf.go
+++ b/internal/corazawaf/waf.go
@@ -184,10 +184,13 @@ func (w *WAF) newTransactionWithID(id string) *Transaction {
 		tx.RequestBodyBuffer = NewBodyBuffer(types.BodyBufferOptions{
 			TmpPath:     w.TmpDir,
 			MemoryLimit: w.RequestBodyInMemoryLimit,
+			Limit:       tx.WAF.RequestBodyLimit,
 		})
 		tx.ResponseBodyBuffer = NewBodyBuffer(types.BodyBufferOptions{
-			TmpPath:     w.TmpDir,
-			MemoryLimit: w.RequestBodyInMemoryLimit,
+			TmpPath: w.TmpDir,
+			// the response body is just buffered in memory. Therefore, Limit and MemoryLimit are equal.
+			MemoryLimit: w.ResponseBodyLimit,
+			Limit:       w.ResponseBodyLimit,
 		})
 		tx.variables = *NewTransactionVariables()
 		tx.transformationCache = map[transformationKey]*transformationValue{}

--- a/types/waf.go
+++ b/types/waf.go
@@ -193,4 +193,6 @@ type BodyBufferOptions struct {
 	// MemoryLimit is the maximum amount of memory to be stored in memory
 	// Once the limit is reached, the file will be stored on disk
 	MemoryLimit int64
+	// Limit is the overall maximum amount of memory to be stored
+	Limit int64
 }

--- a/types/waf.go
+++ b/types/waf.go
@@ -97,30 +97,19 @@ func (re RuleEngineStatus) String() string {
 	return "unknown"
 }
 
-// RequestBodyLimitAction represents the action
+// BodyLimitAction represents the action
 // to take when the request body size exceeds
 // the configured limit.
-type RequestBodyLimitAction int
+type BodyLimitAction int
 
 const (
-	// RequestBodyLimitActionProcessPartial will process the request body
+	// BodyLimitActionProcessPartial will process the request body
 	// up to the limit and then reject the request
-	RequestBodyLimitActionProcessPartial RequestBodyLimitAction = 0
-	// RequestBodyLimitActionReject will reject the request in case
+	BodyLimitActionProcessPartial BodyLimitAction = 0
+	// BodyLimitActionReject will reject the request in case
 	// the request body size exceeds the configured limit
-	RequestBodyLimitActionReject RequestBodyLimitAction = 1
+	BodyLimitActionReject BodyLimitAction = 1
 )
-
-// ParseRequestBodyLimitAction parses the request body limit action
-func ParseRequestBodyLimitAction(rbla string) (RequestBodyLimitAction, error) {
-	switch strings.ToLower(rbla) {
-	case "processpartial":
-		return RequestBodyLimitActionProcessPartial, nil
-	case "reject":
-		return RequestBodyLimitActionReject, nil
-	}
-	return -1, fmt.Errorf("invalid request body limit action: %s", rbla)
-}
 
 type auditLogPart byte
 
@@ -193,4 +182,8 @@ type BodyBufferOptions struct {
 	// MemoryLimit is the maximum amount of memory to be stored in memory
 	// Once the limit is reached, the file will be stored on disk
 	MemoryLimit int64
+	// Limit is the overall maximum amount of memory to be buffered
+	Limit int64
+	// Wheter discard or not the payload after the limit is reached.
+	DiscardOnBodyLimit bool
 }

--- a/types/waf.go
+++ b/types/waf.go
@@ -193,6 +193,4 @@ type BodyBufferOptions struct {
 	// MemoryLimit is the maximum amount of memory to be stored in memory
 	// Once the limit is reached, the file will be stored on disk
 	MemoryLimit int64
-	// Limit is the overall maximum amount of memory to be stored
-	Limit int64
 }


### PR DESCRIPTION
This PR attempts to do a best effort to avoid further buffering beyond the limit when the action is to reject. See the rationale https://github.com/M4tteoP/coraza/pull/1/files#diff-69f3600597ab06677a12ed2bc0e8b9e078699494de5d487db06a9a019fce9fc3R5